### PR TITLE
Refactoring Web3Service to extract MetaCoin logic/introducing async/await

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ to install dependencies. In order install these dependencies, you will also need
 
 1. Install truffle, Angular CLI and an Ethereum client. If you don't have a test environment, we recommend Ethereum TestRPC
   ```bash
-  npm install -g truffle
+  npm install -g truffle@3.4.6
   npm install -g @angular/cli
   npm install -g ethereumjs-testrpc
   ```

--- a/ci/build.sh
+++ b/ci/build.sh
@@ -4,7 +4,10 @@ set -e
 truffle compile
 
 testrpc > /dev/null &
+TESTRPC_PID=$!
 npm test
 ng e2e
 ng lint
 truffle test
+
+kill $TESTRPC_PID

--- a/ci/install-deps.sh
+++ b/ci/install-deps.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env sh
 set -x
 npm install -g @angular/cli
-npm install -g truffle
+npm install -g truffle@3.4.6
 npm install -g ethereumjs-testrpc 
 npm install

--- a/src/app/util/web3.service.spec.ts
+++ b/src/app/util/web3.service.spec.ts
@@ -1,26 +1,14 @@
-import { TestBed, inject } from '@angular/core/testing';
+import {TestBed, inject} from '@angular/core/testing';
+import Web3 from 'web3';
 
 import {Web3Service} from './web3.service';
+
+import metacoin_artifacts from '../../../build/contracts/MetaCoin.json';
 
 declare let window: any;
 
 describe('Web3Service', () => {
   beforeEach(() => {
-    const currentProvider = {
-      test: 5
-    };
-
-    const getAccounts = (callback) => {
-          callback(0, ['0xdeadbeefdeadbeefdeadbeef']);
-        };
-
-    const mockWeb3 = {
-      currentProvider: currentProvider,
-      eth: {
-        getAccounts: getAccounts
-      }
-    };
-    window.web3 = mockWeb3;
     TestBed.configureTestingModule({
       providers: [Web3Service]
     });
@@ -28,5 +16,25 @@ describe('Web3Service', () => {
 
   it('should be created', inject([Web3Service], (service: Web3Service) => {
     expect(service).toBeTruthy();
+  }));
+
+  it('should inject a default web3 on a contract', inject([Web3Service], (service: Web3Service) => {
+    service.bootstrapWeb3();
+
+    return service.artifactsToContract(metacoin_artifacts).then((abstraction) => {
+      expect(abstraction.currentProvider.host).toBe("http://localhost:8545");
+    });
+  }));
+
+  it('should inject a the window web3 on a contract', inject([Web3Service], (service: Web3Service) => {
+    window.web3 = {
+      currentProvider: new Web3.providers.HttpProvider('http://localhost:1337')
+    };
+
+    service.bootstrapWeb3();
+
+    return service.artifactsToContract(metacoin_artifacts).then((abstraction) => {
+      expect(abstraction.currentProvider.host).toBe("http://localhost:1337");
+    })
   }));
 });

--- a/src/app/util/web3.service.spec.ts
+++ b/src/app/util/web3.service.spec.ts
@@ -22,7 +22,7 @@ describe('Web3Service', () => {
     service.bootstrapWeb3();
 
     return service.artifactsToContract(metacoin_artifacts).then((abstraction) => {
-      expect(abstraction.currentProvider.host).toBe("http://localhost:8545");
+      expect(abstraction.currentProvider.host).toBe('http://localhost:8545');
     });
   }));
 
@@ -34,7 +34,7 @@ describe('Web3Service', () => {
     service.bootstrapWeb3();
 
     return service.artifactsToContract(metacoin_artifacts).then((abstraction) => {
-      expect(abstraction.currentProvider.host).toBe("http://localhost:1337");
-    })
+      expect(abstraction.currentProvider.host).toBe('http://localhost:1337');
+    });
   }));
 });

--- a/src/app/util/web3.service.ts
+++ b/src/app/util/web3.service.ts
@@ -15,18 +15,25 @@ export class Web3Service {
 
   constructor() {
     window.addEventListener('load', (event) => {
-      // Checking if Web3 has been injected by the browser (Mist/MetaMask)
-      if (typeof window.web3 !== 'undefined') {
-        // Use Mist/MetaMask's provider
-        this.web3 = new Web3(window.web3.currentProvider);
-      } else {
-        console.log('No web3? You should consider trying MetaMask!');
-        // fallback - use your fallback strategy (local node / hosted node + in-dapp id mgmt / fail)
-        this.web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
-      }
-
-      setInterval(() => this.refreshAccounts(), 100);
+      this.bootstrapWeb3();
     });
+  }
+
+  public bootstrapWeb3() {
+    // Checking if Web3 has been injected by the browser (Mist/MetaMask)
+    if (typeof window.web3 !== 'undefined') {
+      // Use Mist/MetaMask's provider
+      this.web3 = new Web3(window.web3.currentProvider);
+    } else {
+      console.log('No web3? You should consider trying MetaMask!');
+
+      // Hack to provide backwards compatibility for Truffle, which uses web3js 0.20.x
+      Web3.providers.HttpProvider.prototype.sendAsync = Web3.providers.HttpProvider.prototype.send;
+      // fallback - use your fallback strategy (local node / hosted node + in-dapp id mgmt / fail)
+      this.web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
+    }
+
+    setInterval(() => this.refreshAccounts(), 100);
   }
 
   public async artifactsToContract(artifacts) {

--- a/src/app/util/web3.service.ts
+++ b/src/app/util/web3.service.ts
@@ -1,7 +1,6 @@
 import {Injectable} from '@angular/core';
 import Web3 from 'web3';
 import {default as contract} from 'truffle-contract';
-import metacoin_artifacts from '../../../build/contracts/MetaCoin.json';
 import {Subject} from 'rxjs/Rx';
 
 declare let window: any;
@@ -15,8 +14,6 @@ export class Web3Service {
   public accountsObservable = new Subject<string[]>();
 
   constructor() {
-    this.MetaCoin = contract(metacoin_artifacts);
-
     window.addEventListener('load', (event) => {
       // Checking if Web3 has been injected by the browser (Mist/MetaMask)
       if (typeof window.web3 !== 'undefined') {
@@ -27,9 +24,22 @@ export class Web3Service {
         // fallback - use your fallback strategy (local node / hosted node + in-dapp id mgmt / fail)
         this.web3 = new Web3(new Web3.providers.HttpProvider('http://localhost:8545'));
       }
-      this.MetaCoin.setProvider(this.web3.currentProvider);
+
       setInterval(() => this.refreshAccounts(), 100);
     });
+  }
+
+  public async artifactsToContract(artifacts) {
+    if (!this.web3) {
+      const delay = new Promise(resolve => setTimeout(resolve, 100));
+      await delay;
+      return await this.artifactsToContract(artifacts);
+    }
+
+    const contractAbstraction = contract(artifacts);
+    contractAbstraction.setProvider(this.web3.currentProvider);
+    return contractAbstraction;
+
   }
 
   private refreshAccounts() {


### PR DESCRIPTION
@sarbogast You had already suggested this to be a good idea. The way I have it currently, it also encapsulates truffle-contract in the same Service. This makes it less generic, but we could again seperate out the Web3 stuff if we would want to extract it to a very generic library. 