### PR TITLE
Fixes to accomodate truffle 3 -> 4 limbo

### DIFF
--- a/ci/build.sh
+++ b/ci/build.sh
@@ -1,11 +1,12 @@
 #!/usr/bin/env sh
 set -x
 set -e
+testrpc -l 100000000 > /dev/null &
+TESTRPC_PID=$!
+
 truffle compile
 truffle test
 
-testrpc > /dev/null &
-TESTRPC_PID=$!
 npm test
 ng e2e
 ng lint


### PR DESCRIPTION
Starting testrpc before truffle test, because reinstating the
development network causes `truffle test` not to start the built-in
Ganache.

Increasing the gas limit, because solc optimization is turned off
by default in truffle 4