### PR TITLE
Changed tx.origin to msg.sender because the tx.origin can result in u…

### DIFF
--- a/contracts/MetaCoin.sol
+++ b/contracts/MetaCoin.sol
@@ -13,7 +13,7 @@ contract MetaCoin {
 	event Transfer(address indexed _from, address indexed _to, uint256 _value);
 
 	function MetaCoin() public {
-		balances[tx.origin] = 10000;
+		balances[msg.sender] = 10000;
 	}
 
 	function sendCoin(address receiver, uint amount) public returns(bool sufficient) {


### PR DESCRIPTION
tx.origin can result in unexpected behaviour when the transaction comes from other smart contracts. It is therefore not safe unless you know exactly what the implicatations are. In this code msg.sender is most likely preferred.